### PR TITLE
Babel ignore

### DIFF
--- a/lib/babel-worker.js
+++ b/lib/babel-worker.js
@@ -10,7 +10,7 @@ function workerFunc() {
   self.addEventListener('message', function (event) {
     const code = Babel.transform(
       event.data.code,
-      event.data.babelrc
+      event.data.options
     ).code;
 
     self.postMessage({

--- a/samples/hack-rpg/.babelrc
+++ b/samples/hack-rpg/.babelrc
@@ -1,11 +1,8 @@
 {
-	"presets": [
-		"es2015", "stage-3"
-	]
+    "presets": [
+        "es2015", "stage-3"
+    ],
+    "ignore": [
+        "stages/3/code.js"
+    ]
 }
-
-
-
-
-
-

--- a/samples/hack-rpg/stages/3/code.js
+++ b/samples/hack-rpg/stages/3/code.js
@@ -1,4 +1,4 @@
-// stair.opacity = １;
+stair.opacity = １;
 
 
 // このへやに 出口が ないのは CODE が まちがっているからです。  

--- a/samples/make-rpg/.babelrc
+++ b/samples/make-rpg/.babelrc
@@ -1,11 +1,8 @@
 {
-	"presets": [
-		"es2015", "stage-3"
-	]
+    "presets": [
+        "es2015", "stage-3"
+    ],
+    "ignore": [
+        "stages/3/code.js"
+    ]
 }
-
-
-
-
-
-

--- a/samples/make-rpg/stages/3/code.js
+++ b/samples/make-rpg/stages/3/code.js
@@ -1,4 +1,4 @@
-// stair.opacity = １;
+stair.opacity = １;
 
 
 // このへやに 出口が ないのは CODE が まちがっているからです。

--- a/src/Monitor/Monitor.jsx
+++ b/src/Monitor/Monitor.jsx
@@ -170,7 +170,8 @@ export default class Monitor extends PureComponent {
     const env = composeEnv(getConfig('env'));
 
     const scriptFiles = this.props.files
-      .filter((file) => !file.options.isTrashed && file.isScript);
+      .filter((file) => !file.options.isTrashed && file.isScript)
+      .filter(file => file.name !== 'stages/3/code.js');
 
     const indicate = ((sent) => () => {
       const progress = Math.min(1, ++sent / scriptFiles.length);

--- a/src/workers/babel-worker.js
+++ b/src/workers/babel-worker.js
@@ -64,7 +64,7 @@ export default function (file, babelrc) {
       worker.postMessage({
         id: id,
         code: file.text,
-        babelrc: babelrc,
+        options: {...babelrc, filename: file.name},
       });
     } else {
       resolve(file);


### PR DESCRIPTION
!! 暫定的な処置

stages/3/code.js というファイル名のファイルをビルドに含めないようにする.
このファイルは samples であえてエラーがあるコードとして利用されており、そのままビルドするとゲームが実行できなくなるため.

そもそもゲームの実行に必要でないコードをビルドに含めることがおかしい. dynamic にすべき.