### PR TITLE
Bugfix beta 8k

### DIFF
--- a/src/Cards/CardContainer.jsx
+++ b/src/Cards/CardContainer.jsx
@@ -165,6 +165,7 @@ class CardContainer extends PureComponent {
         backgroundRepeat: 'no-repeat',
         backgroundPosition: 'center',
         backgroundSize: 'contain',
+        position: 'relative',
       },
       left: {
         position: 'relative',

--- a/src/Menu/Menu.jsx
+++ b/src/Menu/Menu.jsx
@@ -255,6 +255,7 @@ export default class Menu extends PureComponent {
 
   handleLogout = () => {
     this.setState({oAuthId: null});
+    this.handleRequestClose();
   };
 
   handleRequestClose = () => {

--- a/src/Menu/Menu.jsx
+++ b/src/Menu/Menu.jsx
@@ -193,7 +193,8 @@ export default class Menu extends PureComponent {
           'Accept': 'application/json',
           'Content-Type': 'application/x-www-form-urlencoded'
         },
-        body,
+        // [Safari Bug] URLSearchParams not supported in bodyInit
+        body: body.toString(),
         mode: 'cors'
       });
 


### PR DESCRIPTION
URLSearchParams はサポートされていない (Safari)
UVString として初期化するために明示的に toStirng() をコール.